### PR TITLE
Pass user info collector to sentry initializer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,12 @@ COMMIT := $(COMMIT)-dirty
 endif
 BUILD_TIME=`date -u '+%Y-%m-%dT%H:%M:%SZ'`
 
-.DEFAULT_GOAL := help
+.DEFAULT_GOAL := all
+
+# If nothing was specified, run all targets as if in a fresh clone
+.PHONY: all
+## Default target - fetch dependencies and build.
+all: prebuild-check deps build
 
 .PHONY: help
 # Based on https://gist.github.com/rcmachado/af3db315e31383502660

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,11 @@ BUILD_TIME=`date -u '+%Y-%m-%dT%H:%M:%SZ'`
 ## Default target - fetch dependencies and build.
 all: prebuild-check deps build
 
+.PHONY: format-go-code
+## Formats any go file that differs from gofmt's style
+format-go-code: prebuild-check
+	@gofmt -s -l -w ${GOFORMAT_FILES}
+	
 .PHONY: help
 # Based on https://gist.github.com/rcmachado/af3db315e31383502660
 ## display this help text.

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -12,8 +12,8 @@ import (
 // client encapsulates client to Sentry service
 // also has mutex which controls access to the client
 type client struct {
-	c       *raven.Client
-	sendErr chan func()
+	c        *raven.Client
+	sendErr  chan func()
 	userInfo func(ctx context.Context) (*raven.User, error)
 }
 
@@ -31,7 +31,7 @@ func Sentry() *client {
 // sentryDSN param is optional. If null then DSN set via SENTRY_DSN env var will be used
 func InitializeSentryClient(sentryDSN *string, options ...func(*client)) (func(), error) {
 	var dsn string
-	if sentryDSN!=nil {
+	if sentryDSN != nil {
 		dsn = *sentryDSN
 	} else {
 		dsn = os.Getenv("SENTRY_DSN")
@@ -98,7 +98,7 @@ func (c *client) CaptureError(ctx context.Context, err error) {
 	// Extract user information. Ignoring error here but then before using the
 	// object user make sure to check if it wasn't nil.
 	var user *raven.User
-	if c.userInfo!=nil {
+	if c.userInfo != nil {
 		user, _ = c.userInfo(ctx)
 	}
 	reqID := log.ExtractRequestID(ctx)

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -16,8 +16,8 @@ import (
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/pkg/errors"
 	"github.com/satori/go.uuid"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func failOnNoToken(t *testing.T) context.Context {
@@ -51,7 +51,7 @@ func TestExtractUserInfo(t *testing.T) {
 	userID := uuid.NewV4()
 	username := "testuser"
 
-	_, err:=InitializeSentryClient(nil,
+	_, err := InitializeSentryClient(nil,
 		WithUser(func(ctx context.Context) (*raven.User, error) {
 			m, err := token.ReadManagerFromContext(ctx)
 			if err != nil {
@@ -125,23 +125,23 @@ func TestExtractUserInfo(t *testing.T) {
 
 func TestDSN(t *testing.T) {
 	// Set default DSN via env var
-	defaultProject:=uuid.NewV4()
-	dsn:= fmt.Sprintf("https://%s:%s@test.io/%s", uuid.NewV4(), uuid.NewV4(), defaultProject)
-	old:=os.Getenv("SENTRY_DSN")
+	defaultProject := uuid.NewV4()
+	dsn := fmt.Sprintf("https://%s:%s@test.io/%s", uuid.NewV4(), uuid.NewV4(), defaultProject)
+	old := os.Getenv("SENTRY_DSN")
 	os.Setenv("SENTRY_DSN", dsn)
 	defer os.Setenv("SENTRY_DSN", old)
 
 	// Init DSN explicitly
-	project:=uuid.NewV4()
-	dsn= fmt.Sprintf("https://%s:%s@test.io/%s", uuid.NewV4(), uuid.NewV4(), project)
-	_, err:=InitializeSentryClient(&dsn)
+	project := uuid.NewV4()
+	dsn = fmt.Sprintf("https://%s:%s@test.io/%s", uuid.NewV4(), uuid.NewV4(), project)
+	_, err := InitializeSentryClient(&dsn)
 	require.NoError(t, err)
 
 	// The env var is not used. Explicitly set DSN is used instead.
 	assert.Equal(t, fmt.Sprintf("https://test.io/api/%s/store/", project), Sentry().c.URL())
 
 	// Init the default DSN
-	_, err=InitializeSentryClient(nil)
+	_, err = InitializeSentryClient(nil)
 	require.NoError(t, err)
 
 	// The DSN from the env var is used

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -44,13 +44,14 @@ func validToken(t *testing.T, identityID string, identityUsername string) contex
 	ctx = goajwt.WithJWT(ctx, token)
 	return ctx
 }
+
 func TestExtractUserInfo(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 
 	userID := uuid.NewV4()
 	username := "testuser"
 
-	InitializeSentryClient(nil,
+	_, err:=InitializeSentryClient(nil,
 		WithUser(func(ctx context.Context) (*raven.User, error) {
 			m, err := token.ReadManagerFromContext(ctx)
 			if err != nil {
@@ -73,6 +74,7 @@ func TestExtractUserInfo(t *testing.T) {
 				ID:       t.Subject,
 			}, nil
 		}))
+	require.NoError(t, err)
 
 	tests := []struct {
 		name    string
@@ -132,13 +134,15 @@ func TestDSN(t *testing.T) {
 	// Init DSN explicitly
 	project:=uuid.NewV4()
 	dsn= fmt.Sprintf("https://%s:%s@test.io/%s", uuid.NewV4(), uuid.NewV4(), project)
-	InitializeSentryClient(&dsn)
+	_, err:=InitializeSentryClient(&dsn)
+	require.NoError(t, err)
 
 	// The env var is not used. Explicitly set DSN is used instead.
 	assert.Equal(t, fmt.Sprintf("https://test.io/api/%s/store/", project), Sentry().c.URL())
 
 	// Init the default DSN
-	InitializeSentryClient(nil)
+	_, err=InitializeSentryClient(nil)
+	require.NoError(t, err)
 
 	// The DSN from the env var is used
 	assert.Equal(t, fmt.Sprintf("https://test.io/api/%s/store/", defaultProject), Sentry().c.URL())

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -2,18 +2,22 @@ package sentry
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-common/login/tokencontext"
 	"github.com/fabric8-services/fabric8-common/resource"
 	testtoken "github.com/fabric8-services/fabric8-common/test/token"
+	"github.com/fabric8-services/fabric8-common/token"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/getsentry/raven-go"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func failOnNoToken(t *testing.T) context.Context {
@@ -40,11 +44,35 @@ func validToken(t *testing.T, identityID string, identityUsername string) contex
 	ctx = goajwt.WithJWT(ctx, token)
 	return ctx
 }
-func Test_extractUserInfo(t *testing.T) {
+func TestExtractUserInfo(t *testing.T) {
 	resource.Require(t, resource.UnitTest)
 
 	userID := uuid.NewV4()
 	username := "testuser"
+
+	InitializeSentryClient(nil,
+		WithUser(func(ctx context.Context) (*raven.User, error) {
+			m, err := token.ReadManagerFromContext(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			q := *m
+			token := goajwt.ContextJWT(ctx)
+			if token == nil {
+				return nil, fmt.Errorf("no token found in context")
+			}
+			t, err := q.ParseToken(ctx, token.Raw)
+			if err != nil {
+				return nil, err
+			}
+
+			return &raven.User{
+				Username: t.Username,
+				Email:    t.Email,
+				ID:       t.Subject,
+			}, nil
+		}))
 
 	tests := []struct {
 		name    string
@@ -80,7 +108,7 @@ func Test_extractUserInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := extractUserInfo(tt.ctx)
+			got, err := Sentry().userInfo(tt.ctx)
 			if tt.wantErr {
 				require.Error(t, err)
 				// if above assertion passes we don't need to continue
@@ -91,4 +119,27 @@ func Test_extractUserInfo(t *testing.T) {
 			require.Equalf(t, tt.want, got, "extractUserInfo() = %v, want %v", got, tt.want)
 		})
 	}
+}
+
+func TestDSN(t *testing.T) {
+	// Set default DSN via env var
+	defaultProject:=uuid.NewV4()
+	dsn:= fmt.Sprintf("https://%s:%s@test.io/%s", uuid.NewV4(), uuid.NewV4(), defaultProject)
+	old:=os.Getenv("SENTRY_DSN")
+	os.Setenv("SENTRY_DSN", dsn)
+	defer os.Setenv("SENTRY_DSN", old)
+
+	// Init DSN explicitly
+	project:=uuid.NewV4()
+	dsn= fmt.Sprintf("https://%s:%s@test.io/%s", uuid.NewV4(), uuid.NewV4(), project)
+	InitializeSentryClient(&dsn)
+
+	// The env var is not used. Explicitly set DSN is used instead.
+	assert.Equal(t, fmt.Sprintf("https://test.io/api/%s/store/", project), Sentry().c.URL())
+
+	// Init the default DSN
+	InitializeSentryClient(nil)
+
+	// The DSN from the env var is used
+	assert.Equal(t, fmt.Sprintf("https://test.io/api/%s/store/", defaultProject), Sentry().c.URL())
 }


### PR DESCRIPTION
The current sentry package is unusable because it tries to load TokenManager from context but it's always nil.

1. This PR changes the sentry initializer. Now it expects userInfo(ctx context) function which is to be used to provide user info.

The usage of the initializer:

```
haltSentry, err := sentry.InitializeSentryClient(nil,
	sentry.WithRelease(commit),
	sentry.WithEnvironment(environment),
	sentry.WithUser(func(ctx context.Context) (*raven.User, error) {
		m, err := token.ReadManagerFromContext(ctx)
		if err != nil {
			return nil, err
		}
	
		q := *m
		token := goajwt.ContextJWT(ctx)
		if token == nil {
			return nil, fmt.Errorf("no token found in context")
		}
		t, err := q.ParseToken(ctx, token.Raw)
		if err != nil {
			return nil, err
		}
	
		return &raven.User{
			Username: t.Username,
			Email:    t.Email,
			ID:       t.Subject,
		}, nil
	}))
```

2. It's now possible to explicitly set Sentry DSN. If not specified then SENTRY_DSN env var will be used:
`sentry.InitializeSentryClient(dsn)` vs `sentry.InitializeSentryClient(nil)`

3. The default make target is now 'all' (prebuild-check deps build) instead of 'help'