### PR TITLE
Add HTTP Proxy

### DIFF
--- a/http/proxy/proxy.go
+++ b/http/proxy/proxy.go
@@ -1,0 +1,180 @@
+package proxy
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/fabric8-services/fabric8-common/log"
+
+	"github.com/goadesign/goa"
+	"github.com/pkg/errors"
+)
+
+// RouteHTTPToPath uses a reverse proxy to route the http request to the scheme, host provided in targetHost
+// and path provided in targetPath.
+//
+// Usage example in Goa controller (listen to http://localhost:8080) if the request is to proxy to Auth service:
+//  err := proxy.RouteHTTP(ctx, "http://auth", "/api/status")
+//	if err != nil {
+//		return jsonapi.JSONErrorResponse(ctx, err)
+//	}
+// In the example above any request to http://localhost:8080/test?id=xyz will be routed to http://auth/api/status?id=xyz
+func RouteHTTPToPath(ctx context.Context, targetHost string, targetPath string) error {
+	return route(ctx, targetHost, &targetPath)
+}
+
+// RouteHTTP uses a reverse proxy to route the http request to the scheme, host, and base path provided in target.
+// If the target's path is "/base" and the incoming request was for "/dir",
+// the target request will be for /base/dir.
+//
+// Usage example in Goa controller (listen to http://localhost:8080) if the request is to proxy to Auth service:
+//  err := proxy.RouteHTTP(ctx, "http://auth")
+//	if err != nil {
+//		return jsonapi.JSONErrorResponse(ctx, err)
+//	}
+// In the example above any request to http://localhost:8080/status?id=xyz will be routed to http://auth/status?id=xyz
+func RouteHTTP(ctx context.Context, target string) error {
+	return route(ctx, target, nil)
+}
+
+func route(ctx context.Context, targetHost string, targetPath *string) error {
+	rw := goa.ContextResponse(ctx)
+	if rw == nil {
+		return errors.New("unable to get response from context")
+	}
+	req := goa.ContextRequest(ctx)
+	if req == nil {
+		return errors.New("unable to get request from context")
+	}
+
+	targetURL, err := url.Parse(targetHost)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err":         err,
+			"target_host": targetHost,
+			"request_uri": req.RequestURI,
+		}, "unable to parse target host")
+		return err
+	}
+
+	director := newDirector(ctx, req, targetURL, targetPath)
+	proxy := &httputil.ReverseProxy{Director: director}
+
+	if strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
+		gzr := gunzipResponseWriter{ctx: ctx, ResponseWriter: rw, targetURL: *req.URL}
+		proxy.ServeHTTP(gzr, req.Request)
+	} else {
+		proxy.ServeHTTP(rw, req.Request)
+	}
+
+	return nil
+}
+
+func newDirector(ctx context.Context, originalRequestData *goa.RequestData, target *url.URL, targetPath *string) func(*http.Request) {
+	targetQuery := target.RawQuery
+	return func(req *http.Request) {
+		// Get the original request URL for info log
+		scheme := "http"
+		if req.URL != nil && req.URL.Scheme == "https" { // isHTTPS
+			scheme = "https"
+		}
+		xForwardProto := req.Header.Get("X-Forwarded-Proto")
+		if xForwardProto != "" {
+			scheme = xForwardProto
+		}
+		originalReq := &url.URL{Scheme: scheme, Host: originalRequestData.Host, Path: req.URL.Path, RawQuery: req.URL.RawQuery}
+
+		// Modify the request to route to a new target
+		if target.Scheme == "" {
+			req.URL.Scheme = "http"
+		} else {
+			req.URL.Scheme = target.Scheme
+		}
+		req.URL.Host = target.Host
+		if targetPath != nil {
+			req.URL.Path = *targetPath
+		} else {
+			req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
+		}
+		if targetQuery == "" || req.URL.RawQuery == "" {
+			req.URL.RawQuery = targetQuery + req.URL.RawQuery
+		} else {
+			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
+		}
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to default value
+			req.Header.Set("User-Agent", "")
+		}
+		requestID := log.ExtractRequestID(ctx)
+		if requestID != "" {
+			req.Header.Set("X-Request-ID", requestID)
+		}
+
+		// Log the original and target URLs
+		originalReqString := originalReq.String()
+		targetReqString := req.URL.String()
+		log.Info(ctx, map[string]interface{}{
+			"original_req_url": originalReqString,
+			"target_req_url":   targetReqString,
+			"target":           target,
+			"target_string":    target.String(),
+		}, "Routing %s to %s", originalReqString, targetReqString)
+	}
+}
+
+type gunzipResponseWriter struct {
+	http.ResponseWriter
+	ctx       context.Context
+	targetURL url.URL
+}
+
+func (w gunzipResponseWriter) Write(b []byte) (int, error) {
+	// Write gunzipped data to the client
+	gr, err := gzip.NewReader(bytes.NewBuffer(b))
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		err := gr.Close()
+		if err != nil {
+			log.Error(w.ctx, map[string]interface{}{
+				"err":        err,
+				"target_url": w.targetURL.String(),
+			}, "unable to close gzip writer while serving request in proxy")
+		}
+	}()
+	data, err := ioutil.ReadAll(gr)
+	if err != nil {
+		return 0, err
+	}
+	return w.ResponseWriter.Write(data)
+}
+
+func (w gunzipResponseWriter) WriteHeader(code int) {
+	w.Header().Del("Content-Length")
+	// Remove duplicated headers
+	for key, value := range w.Header() {
+		if len(value) > 0 {
+			w.Header().Set(key, value[0])
+		}
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
+}

--- a/http/proxy/proxy_test.go
+++ b/http/proxy/proxy_test.go
@@ -44,7 +44,8 @@ func TestProxy(t *testing.T) {
 
 	assert.Equal(t, 201, rw.Code)
 	assert.Equal(t, "proxyTest", rw.Header().Get("Custom-Test-Header"))
-	body := readBody(rw.Result().Body)
+	body, err := readBody(rw.Result().Body)
+	require.NoError(t, err)
 	assert.Equal(t, veryLongBody, body)
 
 	// POST, gzipped, changed target path
@@ -62,7 +63,8 @@ func TestProxy(t *testing.T) {
 
 	assert.Equal(t, 201, rw.Code)
 	assert.Equal(t, "proxyTest", rw.Header().Get("Custom-Test-Header"))
-	body = readBody(rw.Result().Body)
+	body, err = readBody(rw.Result().Body)
+	require.NoError(t, err)
 	assert.Equal(t, veryLongBody, body)
 }
 
@@ -110,7 +112,10 @@ func newStatusContext(ctx context.Context, r *http.Request) *statusContext {
 
 func startServer() {
 	http.HandleFunc("/api", handlerGzip)
-	http.ListenAndServe(":8889", nil)
+	err := http.ListenAndServe(":8889", nil)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func waitForServer(t *testing.T) {
@@ -169,8 +174,8 @@ func generateLongBody() string {
 	return body
 }
 
-func readBody(body io.ReadCloser) string {
+func readBody(body io.ReadCloser) (string, error) {
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(body)
-	return buf.String()
+	_, err := buf.ReadFrom(body)
+	return buf.String(), err
 }

--- a/http/proxy/proxy_test.go
+++ b/http/proxy/proxy_test.go
@@ -1,0 +1,147 @@
+package proxy
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fabric8-services/fabric8-common/resource"
+
+	"github.com/goadesign/goa"
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxy(t *testing.T) {
+	resource.Require(t, resource.UnitTest)
+	go startServer()
+	waitForServer(t)
+
+	// GET with custom header and 201 response
+	rw := httptest.NewRecorder()
+	u, err := url.Parse("http://domain.org/api")
+	require.NoError(t, err)
+	req, err := http.NewRequest("GET", u.String(), nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	goaCtx := goa.NewContext(goa.WithAction(ctx, "ProxyTest"), rw, req, url.Values{})
+
+	statusCtx := newStatusContext(goaCtx, req)
+	statusCtx.Request.Header.Del("Accept-Encoding")
+
+	err = RouteHTTP(statusCtx, "http://localhost:8889")
+	require.NoError(t, err)
+
+	assert.Equal(t, 201, rw.Code)
+	assert.Equal(t, "proxyTest", rw.Header().Get("Custom-Test-Header"))
+	body := readBody(rw.Result().Body)
+	assert.Equal(t, veryLongBody, body)
+
+	// POST, gzipped, changed target path
+	rw = httptest.NewRecorder()
+	req, err = http.NewRequest("POST", u.String(), nil)
+	require.NoError(t, err)
+
+	ctx = context.Background()
+	goaCtx = goa.NewContext(goa.WithAction(ctx, "ProxyTest"), rw, req, url.Values{})
+	statusCtx = newStatusContext(goaCtx, req)
+	statusCtx.Request.Header.Set("Accept-Encoding", "gzip")
+
+	err = RouteHTTPToPath(statusCtx, "http://localhost:8889", "/api")
+	require.NoError(t, err)
+
+	assert.Equal(t, 201, rw.Code)
+	assert.Equal(t, "proxyTest", rw.Header().Get("Custom-Test-Header"))
+	body = readBody(rw.Result().Body)
+	assert.Equal(t, veryLongBody, body)
+}
+
+type statusContext struct {
+	context.Context
+	*goa.ResponseData
+	*goa.RequestData
+}
+
+func newStatusContext(ctx context.Context, r *http.Request) *statusContext {
+	resp := goa.ContextResponse(ctx)
+	req := goa.ContextRequest(ctx)
+	req.Request = r
+	return &statusContext{Context: ctx, ResponseData: resp, RequestData: req}
+}
+
+func startServer() {
+	http.HandleFunc("/api", handlerGzip)
+	http.ListenAndServe(":8889", nil)
+}
+
+func waitForServer(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://localhost:8889/api", nil)
+	require.NoError(t, err)
+	for i := 0; i < 30; i++ {
+		time.Sleep(100 * time.Millisecond)
+		client := &http.Client{Timeout: time.Duration(500 * time.Millisecond)}
+		res, err := client.Do(req)
+		if err == nil && res.StatusCode == 201 {
+			return
+		}
+	}
+	assert.Fail(t, "failed to start server")
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Custom-Test-Header", "proxyTest")
+	w.WriteHeader(201)
+	fmt.Fprint(w, veryLongBody)
+}
+
+func handlerGzip(w http.ResponseWriter, r *http.Request) {
+	if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+		handler(w, r)
+		return
+	}
+	w.Header().Set("Content-Encoding", "gzip")
+	gz := gzip.NewWriter(w)
+	defer gz.Close()
+	gzr := gzipResponseWriter{Writer: gz, ResponseWriter: w}
+	handler(gzr, r)
+}
+
+type gzipResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+}
+
+func (w gzipResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+func (w gzipResponseWriter) WriteHeader(code int) {
+	w.Header().Del("Content-Length")
+	w.ResponseWriter.WriteHeader(code)
+}
+
+var veryLongBody = generateLongBody()
+
+func generateLongBody() string {
+	body := uuid.NewV4().String()
+	for i := 0; i < 100; i++ {
+		body = body + uuid.NewV4().String()
+	}
+	return body
+}
+
+func readBody(body io.ReadCloser) string {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(body)
+	return buf.String()
+}


### PR DESCRIPTION
Usage examples in a Goa controller (listen to http://localhost:8080):

1. In this example any incoming request to `http://localhost:8080/test?id=xyz` will be routed to `http://auth/api/status?id=xyz`:
```
err := proxy.RouteHTTP(ctx, "http://auth", "/api/status")
if err != nil {
    return jsonapi.JSONErrorResponse(ctx, err)
}
```

2. In this example any request to `http://localhost:8080/status?id=xyz` will be routed to `http://auth/status?id=xyz`:
```
err := proxy.RouteHTTP(ctx, "http://auth")
if err != nil {
    return jsonapi.JSONErrorResponse(ctx, err)
}
```