### PR TITLE
Allow overriding viper configs on configuration

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -97,6 +97,12 @@ func New(configFilePath string) (*Registry, error) {
 	return &c, nil
 }
 
+// SetViperConfig allow setting viper init so we can properly do composition of
+// the configuration from other projects
+func (c *Registry) SetViperConfig(v *viper.Viper) {
+	c.v = v
+}
+
 func getConfigFilePath() string {
 	// This was either passed as a env var Or, set inside main.go from --config
 	envConfigPath, ok := os.LookupEnv("F8_CONFIG_FILE_PATH")


### PR DESCRIPTION
To be able to compose configuration of a project with common's conifg we need to
be able to pass our own viper config.

This is a snippet showing how it crash :

https://goplay.space/#AvHU4rW-GLw

and how it works with setting up the viper config :

https://goplay.space/#gRE0V7w0JSa