### PR TITLE
Use /api/token/keys path to fetch public keys

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -439,11 +439,12 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:c40d65817cdd41fac9aa7af8bed56927bb2d6d47e4fea566a74880f5c2b1c41e"
+  digest = "1:5110e3d4f130772fd39e6ce8208ad1955b242ccfcc8ad9d158857250579c82f4"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
     "require",
+    "suite",
   ]
   pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
@@ -592,6 +593,7 @@
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
+    "github.com/stretchr/testify/suite",
     "github.com/wadey/gocovmerge",
     "gopkg.in/square/go-jose.v2",
     "gopkg.in/yaml.v2",

--- a/Makefile
+++ b/Makefile
@@ -237,3 +237,35 @@ endif
 ifndef DEP_BIN
 	$(error The "$(DEP_BIN_NAME)" executable could not be found in your PATH)
 endif
+
+# For the global "clean" target all targets in this variable will be executed
+CLEAN_TARGETS =
+
+CLEAN_TARGETS += clean-artifacts
+.PHONY: clean-artifacts
+## Removes the ./bin directory.
+clean-artifacts:
+	-rm -rf $(INSTALL_PREFIX)
+
+CLEAN_TARGETS += clean-object-files
+.PHONY: clean-object-files
+## Runs go clean to remove any executables or other object files.
+clean-object-files:
+	go clean ./...
+
+CLEAN_TARGETS += clean-generated
+.PHONY: clean-generated
+## Removes all generated code.
+clean-generated:
+	-rm -f ./migration/sqlbindata_test.go
+
+CLEAN_TARGETS += clean-vendor
+.PHONY: clean-vendor
+## Removes the ./vendor directory.
+clean-vendor:
+	-rm -rf $(VENDOR_DIR)
+
+# Keep this "clean" target here at the bottom
+.PHONY: clean
+## Runs all clean-* targets.
+clean: $(CLEAN_TARGETS)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -28,7 +28,6 @@ const (
 	varLogLevel             = "log.level"
 	varDeveloperModeEnabled = "developer.mode.enabled"
 	varAuthURL              = "auth.url"
-	varKeysTokenPath        = "auth.keys.token.path"
 	varEnvironment          = "environment"
 	varLogJSON              = "log.json"
 	varHTTPAddress          = "http.address"
@@ -129,11 +128,6 @@ func (c *Registry) GetLogLevel() string {
 // e.g. token generation endpoint are enabled
 func (c *Registry) DeveloperModeEnabled() bool {
 	return c.v.GetBool(varDeveloperModeEnabled)
-}
-
-// GetKeysTokenPath returns the URL path to retrieve the public keys to verify tokens signature
-func (c *Registry) GetKeysTokenPath() string {
-	return c.v.GetString(varKeysTokenPath)
 }
 
 // GetAuthServiceURL returns the Auth Service URL

--- a/test/configuration/token_manager_configuration.go
+++ b/test/configuration/token_manager_configuration.go
@@ -15,9 +15,6 @@ func NewDefaultMockTokenManagerConfiguration(t *testing.T) *tokensupport.Manager
 		return "https://auth.prod-preview.openshift.io"
 	}
 
-	config.GetAuthKeysPathFunc = func() string {
-		return "/api/token/keys"
-	}
 	config.GetDevModePrivateKeyFunc = func() []byte {
 		return []byte(testkeys.DevModePrivateKey)
 	}

--- a/test/suite/unit_test_suite.go
+++ b/test/suite/unit_test_suite.go
@@ -1,0 +1,21 @@
+package suite
+
+import (
+	"github.com/fabric8-services/fabric8-common/resource"
+	"github.com/stretchr/testify/suite"
+)
+
+// NewRemoteTestSuite instantiates a new UnitTestSuite
+func NewUnitTestSuite() UnitTestSuite {
+	return UnitTestSuite{}
+}
+
+// RemoteTestSuite is a base for unit tests
+type UnitTestSuite struct {
+	suite.Suite
+}
+
+// SetupSuite implements suite.SetupAllSuite
+func (s *UnitTestSuite) SetupSuite() {
+	resource.Require(s.T(), resource.UnitTest)
+}

--- a/token/token.go
+++ b/token/token.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"crypto/rsa"
 	"fmt"
-	"github.com/fabric8-services/fabric8-common/httpsupport"
 	"net/http"
 
 	errs "github.com/fabric8-services/fabric8-common/errors"
+	"github.com/fabric8-services/fabric8-common/httpsupport"
 	"github.com/fabric8-services/fabric8-common/log"
 	"github.com/fabric8-services/fabric8-common/token/jwk"
 	"github.com/fabric8-services/fabric8-common/token/tokencontext"
@@ -36,7 +36,6 @@ const (
 // ManagerConfiguration represents configuration needed to construct a token manager
 type ManagerConfiguration interface {
 	GetAuthServiceURL() string
-	GetAuthKeysPath() string
 	GetDevModePrivateKey() []byte
 }
 
@@ -83,7 +82,9 @@ func NewManager(config ManagerConfiguration, options ...httpsupport.HTTPClientOp
 	}
 	tm.config = config
 
-	keysEndpoint := fmt.Sprintf("%s%s", config.GetAuthServiceURL(), config.GetAuthKeysPath())
+	authURL := httpsupport.AddTrailingSlashToURL(config.GetAuthServiceURL())
+	// TODO when we have a separate repo for Auth client we should use it to get the key path instead of hardcoding "api/token/keys"
+	keysEndpoint := fmt.Sprintf("%s%s", authURL, "api/token/keys")
 	remoteKeys, err := jwk.FetchKeys(keysEndpoint, options...)
 	if err != nil {
 		log.Error(nil, map[string]interface{}{

--- a/token/token_blackbox_test.go
+++ b/token/token_blackbox_test.go
@@ -50,26 +50,26 @@ func (s *TokenManagerTestSuite) TestServiceAccount() {
 		claims["service_accountname"] = serviceName
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.True(s.T(), token.IsServiceAccount(ctx))
+		assert.True(t, token.IsServiceAccount(ctx))
 	})
 	s.T().Run("Missing name", func(t *testing.T) {
 		// given
 		claims := jwt.MapClaims{}
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.False(s.T(), token.IsServiceAccount(ctx))
+		assert.False(t, token.IsServiceAccount(ctx))
 	})
 	s.T().Run("Missing token", func(t *testing.T) {
 		// given
 		ctx := context.Background()
 		// then
-		assert.False(s.T(), token.IsServiceAccount(ctx))
+		assert.False(t, token.IsServiceAccount(ctx))
 	})
 	s.T().Run("Nil token", func(t *testing.T) {
 		// given
 		ctx := goajwt.WithJWT(context.Background(), nil)
 		// then
-		assert.False(s.T(), token.IsServiceAccount(ctx))
+		assert.False(t, token.IsServiceAccount(ctx))
 	})
 	s.T().Run("Wrong data type", func(t *testing.T) {
 		// given
@@ -77,7 +77,7 @@ func (s *TokenManagerTestSuite) TestServiceAccount() {
 		claims["service_accountname"] = 100
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.False(s.T(), token.IsServiceAccount(ctx))
+		assert.False(t, token.IsServiceAccount(ctx))
 	})
 }
 
@@ -89,20 +89,20 @@ func (s *TokenManagerTestSuite) TestSpecificServiceAccount() {
 		claims["service_accountname"] = serviceName
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.True(s.T(), token.IsSpecificServiceAccount(ctx, "dummy-service", serviceName))
+		assert.True(t, token.IsSpecificServiceAccount(ctx, "dummy-service", serviceName))
 	})
 	s.T().Run("Missing name", func(t *testing.T) {
 		// given
 		claims := jwt.MapClaims{}
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.False(s.T(), token.IsSpecificServiceAccount(ctx, serviceName))
+		assert.False(t, token.IsSpecificServiceAccount(ctx, serviceName))
 	})
 	s.T().Run("Nil token", func(t *testing.T) {
 		// given
 		ctx := goajwt.WithJWT(context.Background(), nil)
 		// then
-		assert.False(s.T(), token.IsSpecificServiceAccount(ctx, serviceName))
+		assert.False(t, token.IsSpecificServiceAccount(ctx, serviceName))
 	})
 	s.T().Run("Wrong data type", func(t *testing.T) {
 		// given
@@ -110,13 +110,13 @@ func (s *TokenManagerTestSuite) TestSpecificServiceAccount() {
 		claims["service_accountname"] = 100
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.False(s.T(), token.IsSpecificServiceAccount(ctx, serviceName))
+		assert.False(t, token.IsSpecificServiceAccount(ctx, serviceName))
 	})
 	s.T().Run("Missing token", func(t *testing.T) {
 		// given
 		ctx := context.Background()
 		// then
-		assert.False(s.T(), token.IsSpecificServiceAccount(ctx, serviceName))
+		assert.False(t, token.IsSpecificServiceAccount(ctx, serviceName))
 	})
 	s.T().Run("Wrong name", func(t *testing.T) {
 		// given
@@ -124,7 +124,7 @@ func (s *TokenManagerTestSuite) TestSpecificServiceAccount() {
 		claims["service_accountname"] = serviceName + "_asdsa"
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.False(s.T(), token.IsSpecificServiceAccount(ctx, serviceName))
+		assert.False(t, token.IsSpecificServiceAccount(ctx, serviceName))
 	})
 }
 
@@ -135,7 +135,7 @@ func (s *TokenManagerTestSuite) TestAddLoginRequiredHeader() {
 		// when
 		s.tm.AddLoginRequiredHeader(rw)
 		// then
-		checkLoginRequiredHeader(s.T(), rw)
+		checkLoginRequiredHeader(t, rw)
 	})
 	s.T().Run("with header set", func(t *testing.T) {
 		// given
@@ -144,7 +144,7 @@ func (s *TokenManagerTestSuite) TestAddLoginRequiredHeader() {
 		// when
 		s.tm.AddLoginRequiredHeader(rw)
 		// then
-		checkLoginRequiredHeader(s.T(), rw)
+		checkLoginRequiredHeader(t, rw)
 	})
 }
 
@@ -164,18 +164,18 @@ func (s *TokenManagerTestSuite) TestParseValidTokenOK() {
 		// when
 		claims, err := s.tm.ParseToken(context.Background(), generatedToken)
 		// then
-		require.Nil(s.T(), err)
-		assert.Equal(s.T(), identity.ID.String(), claims.Subject)
-		assert.Equal(s.T(), identity.Username, claims.Username)
+		require.Nil(t, err)
+		assert.Equal(t, identity.ID.String(), claims.Subject)
+		assert.Equal(t, identity.Username, claims.Username)
 	})
 
 	s.T().Run("parse", func(t *testing.T) {
 		// when
 		jwtToken, err := s.tm.Parse(context.Background(), generatedToken)
 		// then
-		require.Nil(s.T(), err)
-		checkClaim(s.T(), jwtToken, "sub", identity.ID.String())
-		checkClaim(s.T(), jwtToken, "preferred_username", identity.Username)
+		require.Nil(t, err)
+		checkClaim(t, jwtToken, "sub", identity.ID.String())
+		checkClaim(t, jwtToken, "preferred_username", identity.Username)
 	})
 }
 
@@ -187,8 +187,8 @@ func (s *TokenManagerTestSuite) TestAuthServiceURL() {
 			return "https://auth.prod-preview.openshift.io"
 		}
 		tm, err := token.NewManager(config)
-		require.NoError(s.T(), err)
-		assert.Len(s.T(), tm.PublicKeys(), 3)
+		require.NoError(t, err)
+		assert.Len(t, tm.PublicKeys(), 3)
 	})
 
 	s.T().Run("OK if auth URL has trailing slash", func(t *testing.T) {
@@ -196,8 +196,8 @@ func (s *TokenManagerTestSuite) TestAuthServiceURL() {
 			return "https://auth.prod-preview.openshift.io/"
 		}
 		tm, err := token.NewManager(config)
-		require.NoError(s.T(), err)
-		assert.Len(s.T(), tm.PublicKeys(), 3)
+		require.NoError(t, err)
+		assert.Len(t, tm.PublicKeys(), 3)
 	})
 
 	s.T().Run("OK if auth URL has trailing slash", func(t *testing.T) {
@@ -205,7 +205,7 @@ func (s *TokenManagerTestSuite) TestAuthServiceURL() {
 			return "https://somedomain.com/"
 		}
 		_, err := token.NewManager(config)
-		require.Error(s.T(), err)
+		require.Error(t, err)
 	})
 }
 
@@ -218,27 +218,27 @@ func checkClaim(t *testing.T, token *jwt.Token, claimName string, expectedValue 
 
 func (s *TokenManagerTestSuite) TestParseToken() {
 	s.T().Run("Invalid token format", func(t *testing.T) {
-		checkInvalidToken(s.T(), s.tm, "7423742yuuiy-INVALID-73842342389h", "token contains an invalid number of segments")
+		checkInvalidToken(t, s.tm, "7423742yuuiy-INVALID-73842342389h", "token contains an invalid number of segments")
 	})
 
 	s.T().Run("Missing kid", func(t *testing.T) {
-		checkInvalidToken(s.T(), s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.mx6DrW3kUQEvsz5Bmaea3nXD9_DB5fBDyNIfanr3u_RFWQyV0romzrAjBP3dKz_dgTS4S5WX2Q1XZiPLjc13PMTCQTNUXp6bFJ5RlDEqX6rJP0Ps9X7bke1pcqS7RhV9cnR1KNH8428bYoKCV57eQnhWtQoCQC1Db6YWJoQNJJLt0IHKCOx7c06r01VF1zcIk1dHnzzz9Qv5aACGXAi8iEJsQ1vURSh7fMETfSJl0UrLJsxGo60fHX9p74cu7bcgD-Zj86axRfgbaHuxn1MMJblltcPsG_TnsMOtmqQr4wlszWTQzwbLnemn8XfwPU8XYc49rVnkiZoB9-BV-oYIxg", "There is no 'kid' header in the token")
+		checkInvalidToken(t, s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.mx6DrW3kUQEvsz5Bmaea3nXD9_DB5fBDyNIfanr3u_RFWQyV0romzrAjBP3dKz_dgTS4S5WX2Q1XZiPLjc13PMTCQTNUXp6bFJ5RlDEqX6rJP0Ps9X7bke1pcqS7RhV9cnR1KNH8428bYoKCV57eQnhWtQoCQC1Db6YWJoQNJJLt0IHKCOx7c06r01VF1zcIk1dHnzzz9Qv5aACGXAi8iEJsQ1vURSh7fMETfSJl0UrLJsxGo60fHX9p74cu7bcgD-Zj86axRfgbaHuxn1MMJblltcPsG_TnsMOtmqQr4wlszWTQzwbLnemn8XfwPU8XYc49rVnkiZoB9-BV-oYIxg", "There is no 'kid' header in the token")
 	})
 
 	s.T().Run("Unknown kid", func(t *testing.T) {
-		checkInvalidToken(s.T(), s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InVua25vd25raWQifQ.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.ewwDOye1c5mA91YjgMQvk0x4RCXeosKVgag-UeG5lHQASWPv3_cpw0BMahG6-eJw1FTvnMFHlcH1Smw-Nfh43qKUpdgWL7QpVbLHiOgvfcsk1g3-G0QFBZ-N-xh35L53Cp5_seXionSAGjsNWLqStQaHPXJ9jLAc_JYLds1VO2CJ0tPSyJ0kiC8fiyRP17pJ19hiHonnGUAZlfZGPJZhrBCfAx3NBbejE0ZAUoeIAw1wPQJDCfp93vO5jvn0kUubpHlnAFz0YtLKqUfaiw6PfZDpu_HTpxAMVvyY_4PxzP56lWdnqQh6JhiMuVNehJfnKcAKPu4WboNCVVIBW3Gppg", "There is no public key with such ID: unknownkid")
+		checkInvalidToken(t, s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InVua25vd25raWQifQ.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.ewwDOye1c5mA91YjgMQvk0x4RCXeosKVgag-UeG5lHQASWPv3_cpw0BMahG6-eJw1FTvnMFHlcH1Smw-Nfh43qKUpdgWL7QpVbLHiOgvfcsk1g3-G0QFBZ-N-xh35L53Cp5_seXionSAGjsNWLqStQaHPXJ9jLAc_JYLds1VO2CJ0tPSyJ0kiC8fiyRP17pJ19hiHonnGUAZlfZGPJZhrBCfAx3NBbejE0ZAUoeIAw1wPQJDCfp93vO5jvn0kUubpHlnAFz0YtLKqUfaiw6PfZDpu_HTpxAMVvyY_4PxzP56lWdnqQh6JhiMuVNehJfnKcAKPu4WboNCVVIBW3Gppg", "There is no public key with such ID: unknownkid")
 	})
 
 	s.T().Run("Invalid signature", func(t *testing.T) {
-		checkInvalidToken(s.T(), s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC5jb20ifQ.Y66kbPnxdfWyuawsEABDTsPFAylC9UFj934pF7SG-Fwrfqs3iF0gVHAQ56WLwY7E-D4QX_3uUkYuSrjzd4JT1p0bfxt3uu0wzFQlnzB4Uu2ttS287XPkBss4mUlc5uvAj0FRdy1IrQBFnfFpW5s6PWrHqod9PF4R2BTCBO1JqKgRtGzSqFwuWHowW__Sgw3B2NVgplL-6rb762M1OeT0GFWt0QE_uG8k_LPGPTyxDR5AILGfRgz5p-d16SYCAsjbsGSiQh3OGArt3Gzfi3CsKIGsQnhfuVXiorFbUn-nVaDuxRwU7JDzhde5nAj38U7exrkgxhEkybGMe4xZme49vA", "crypto/rsa: verification error")
+		checkInvalidToken(t, s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC5jb20ifQ.Y66kbPnxdfWyuawsEABDTsPFAylC9UFj934pF7SG-Fwrfqs3iF0gVHAQ56WLwY7E-D4QX_3uUkYuSrjzd4JT1p0bfxt3uu0wzFQlnzB4Uu2ttS287XPkBss4mUlc5uvAj0FRdy1IrQBFnfFpW5s6PWrHqod9PF4R2BTCBO1JqKgRtGzSqFwuWHowW__Sgw3B2NVgplL-6rb762M1OeT0GFWt0QE_uG8k_LPGPTyxDR5AILGfRgz5p-d16SYCAsjbsGSiQh3OGArt3Gzfi3CsKIGsQnhfuVXiorFbUn-nVaDuxRwU7JDzhde5nAj38U7exrkgxhEkybGMe4xZme49vA", "crypto/rsa: verification error")
 	})
 
 	s.T().Run("Expired", func(t *testing.T) {
-		checkInvalidToken(s.T(), s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjExMTk2MDc5NTIsIm5iZiI6MCwiaWF0IjoxMTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.g90TCdckT5YFctQSwQke7jmeGDZQotYiCa8AE_x0o8M8ncgb6m07glGXgcGJXftkzUL-uZn1U9JzixOYaI8B__jtB9BbMqMnrXyz-_gTYHAlj06l-9axVyKV7cpO8IIt_cFVt5lv4pPEcjEMzDLbjxxo6qH9lihry_KL3zESt8hxaosSnY5b8XvN7WCL-5NYTDF_i7QBI5x8XBljQpTJSwLY6-X7TDgAThET8OgWDV3H40UsSSsJUfpdEJZuiDsqoCsEpb0E7AfiYD-y0iZ5ULSxTiNf0EYf26irmy-jyQlWujOSb9kV2utsywZn-zDmHX3W_hS2wRD5eVgePFTBKA", "token is expired")
+		checkInvalidToken(t, s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjExMTk2MDc5NTIsIm5iZiI6MCwiaWF0IjoxMTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.g90TCdckT5YFctQSwQke7jmeGDZQotYiCa8AE_x0o8M8ncgb6m07glGXgcGJXftkzUL-uZn1U9JzixOYaI8B__jtB9BbMqMnrXyz-_gTYHAlj06l-9axVyKV7cpO8IIt_cFVt5lv4pPEcjEMzDLbjxxo6qH9lihry_KL3zESt8hxaosSnY5b8XvN7WCL-5NYTDF_i7QBI5x8XBljQpTJSwLY6-X7TDgAThET8OgWDV3H40UsSSsJUfpdEJZuiDsqoCsEpb0E7AfiYD-y0iZ5ULSxTiNf0EYf26irmy-jyQlWujOSb9kV2utsywZn-zDmHX3W_hS2wRD5eVgePFTBKA", "token is expired")
 	})
 
 	s.T().Run("OK", func(t *testing.T) {
-		checkValidToken(s.T(), s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.gyoMIWuXnIMMRHewef-__Wkd66qjqSSJxusWcFVtNWaYOXWu7iFV9DhtPVGsbTllXG_lDozPV9BaDmmYRotnn3ZBg7khFDykv9WnoYAjE9vW1d8szNjuoG3tfgQI4Dr9jqopSLndldxq97LGqpxqZFbIDlYd8vN47kv4EePOZDsII6egkTraCMc35eMMilJ4Udd6CMqyV_zaYiGhgAGgeL2ovMFhg_jnc7WhePv7FZkUmtfhCuLUL2TSXS6CyWZYoUDEIcfca6cMzuKOzJoONkDJShNo4u_cQ53duXX_bizdwYNlzBHfIPhSR1LDgV9BXoM6YQnw3It8ReCfF8BEMQ")
+		checkValidToken(t, s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.gyoMIWuXnIMMRHewef-__Wkd66qjqSSJxusWcFVtNWaYOXWu7iFV9DhtPVGsbTllXG_lDozPV9BaDmmYRotnn3ZBg7khFDykv9WnoYAjE9vW1d8szNjuoG3tfgQI4Dr9jqopSLndldxq97LGqpxqZFbIDlYd8vN47kv4EePOZDsII6egkTraCMc35eMMilJ4Udd6CMqyV_zaYiGhgAGgeL2ovMFhg_jnc7WhePv7FZkUmtfhCuLUL2TSXS6CyWZYoUDEIcfca6cMzuKOzJoONkDJShNo4u_cQ53duXX_bizdwYNlzBHfIPhSR1LDgV9BXoM6YQnw3It8ReCfF8BEMQ")
 	})
 
 }
@@ -285,7 +285,7 @@ func (s *TokenManagerTestSuite) TestCheckClaimsFails() {
 		}
 		claimsNoEmail.Subject = uuid.NewV4().String()
 		// then
-		assert.NotNil(s.T(), token.CheckClaims(claimsNoEmail))
+		assert.NotNil(t, token.CheckClaims(claimsNoEmail))
 	})
 
 	s.T().Run("no username", func(t *testing.T) {
@@ -295,7 +295,7 @@ func (s *TokenManagerTestSuite) TestCheckClaimsFails() {
 		}
 		claimsNoUsername.Subject = uuid.NewV4().String()
 		// then
-		assert.NotNil(s.T(), token.CheckClaims(claimsNoUsername))
+		assert.NotNil(t, token.CheckClaims(claimsNoUsername))
 	})
 
 	s.T().Run("no subject", func(t *testing.T) {
@@ -305,7 +305,7 @@ func (s *TokenManagerTestSuite) TestCheckClaimsFails() {
 			Username: "testuser",
 		}
 		// then
-		assert.NotNil(s.T(), token.CheckClaims(claimsNoSubject))
+		assert.NotNil(t, token.CheckClaims(claimsNoSubject))
 	})
 }
 
@@ -319,8 +319,8 @@ func (s *TokenManagerTestSuite) TestLocateTokenInContext() {
 		// when
 		foundId, err := s.tm.Locate(ctx)
 		// then
-		require.NoError(s.T(), err)
-		assert.Equal(s.T(), id, foundId, "ID in created context not equal")
+		require.NoError(t, err)
+		assert.Equal(t, id, foundId, "ID in created context not equal")
 	})
 
 	s.T().Run("missing token in context", func(t *testing.T) {
@@ -329,7 +329,7 @@ func (s *TokenManagerTestSuite) TestLocateTokenInContext() {
 		// when
 		_, err := s.tm.Locate(ctx)
 		// then
-		require.Error(s.T(), err)
+		require.Error(t, err)
 	})
 
 	s.T().Run("missing UUID in token", func(t *testing.T) {
@@ -339,7 +339,7 @@ func (s *TokenManagerTestSuite) TestLocateTokenInContext() {
 		// when
 		_, err := s.tm.Locate(ctx)
 		// then
-		require.Error(s.T(), err)
+		require.Error(t, err)
 	})
 
 	s.T().Run("invalid UUID in token", func(t *testing.T) {
@@ -350,7 +350,7 @@ func (s *TokenManagerTestSuite) TestLocateTokenInContext() {
 		// when
 		_, err := s.tm.Locate(ctx)
 		// then
-		require.Error(s.T(), err)
+		require.Error(t, err)
 
 	})
 }

--- a/token/token_blackbox_test.go
+++ b/token/token_blackbox_test.go
@@ -8,10 +8,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fabric8-services/fabric8-common/resource"
 	testsupport "github.com/fabric8-services/fabric8-common/test"
 	testconfiguration "github.com/fabric8-services/fabric8-common/test/configuration"
+	tokensupport "github.com/fabric8-services/fabric8-common/test/generated/token"
+	testsuite "github.com/fabric8-services/fabric8-common/test/suite"
 	"github.com/fabric8-services/fabric8-common/token"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/dgrijalva/jwt-go"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
@@ -20,125 +22,129 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestServiceAccount(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
+type TokenManagerTestSuite struct {
+	testsuite.UnitTestSuite
+	tm     token.Manager
+	config *tokensupport.ManagerConfigurationMock
+}
 
+func TestRunTokenManagerTestSuite(t *testing.T) {
+	suite.Run(t, &TokenManagerTestSuite{UnitTestSuite: testsuite.NewUnitTestSuite()})
+}
+
+func (s *TokenManagerTestSuite) SetupSuite() {
+	s.UnitTestSuite.SetupSuite()
+
+	s.config = testconfiguration.NewDefaultMockTokenManagerConfiguration(s.T())
+	var err error
+	s.tm, err = token.NewManager(s.config)
+	require.NoError(s.T(), err)
+}
+
+func (s *TokenManagerTestSuite) TestServiceAccount() {
 	serviceName := "test-service"
 
-	t.Run("Valid", func(t *testing.T) {
+	s.T().Run("Valid", func(t *testing.T) {
 		// given
 		claims := jwt.MapClaims{}
 		claims["service_accountname"] = serviceName
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.True(t, token.IsServiceAccount(ctx))
+		assert.True(s.T(), token.IsServiceAccount(ctx))
 	})
-	t.Run("Missing name", func(t *testing.T) {
+	s.T().Run("Missing name", func(t *testing.T) {
 		// given
 		claims := jwt.MapClaims{}
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.False(t, token.IsServiceAccount(ctx))
+		assert.False(s.T(), token.IsServiceAccount(ctx))
 	})
-	t.Run("Missing token", func(t *testing.T) {
+	s.T().Run("Missing token", func(t *testing.T) {
 		// given
 		ctx := context.Background()
 		// then
-		assert.False(t, token.IsServiceAccount(ctx))
+		assert.False(s.T(), token.IsServiceAccount(ctx))
 	})
-	t.Run("Nil token", func(t *testing.T) {
+	s.T().Run("Nil token", func(t *testing.T) {
 		// given
 		ctx := goajwt.WithJWT(context.Background(), nil)
 		// then
-		assert.False(t, token.IsServiceAccount(ctx))
+		assert.False(s.T(), token.IsServiceAccount(ctx))
 	})
-	t.Run("Wrong data type", func(t *testing.T) {
+	s.T().Run("Wrong data type", func(t *testing.T) {
 		// given
 		claims := jwt.MapClaims{}
 		claims["service_accountname"] = 100
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.False(t, token.IsServiceAccount(ctx))
+		assert.False(s.T(), token.IsServiceAccount(ctx))
 	})
 }
 
-func TestSpecificServiceAccount(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
-
+func (s *TokenManagerTestSuite) TestSpecificServiceAccount() {
 	serviceName := "test-service"
-	t.Run("Valid", func(t *testing.T) {
+	s.T().Run("Valid", func(t *testing.T) {
 		// given
 		claims := jwt.MapClaims{}
 		claims["service_accountname"] = serviceName
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.True(t, token.IsSpecificServiceAccount(ctx, "dummy-service", serviceName))
+		assert.True(s.T(), token.IsSpecificServiceAccount(ctx, "dummy-service", serviceName))
 	})
-	t.Run("Missing name", func(t *testing.T) {
+	s.T().Run("Missing name", func(t *testing.T) {
 		// given
 		claims := jwt.MapClaims{}
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.False(t, token.IsSpecificServiceAccount(ctx, serviceName))
+		assert.False(s.T(), token.IsSpecificServiceAccount(ctx, serviceName))
 	})
-	t.Run("Nil token", func(t *testing.T) {
+	s.T().Run("Nil token", func(t *testing.T) {
 		// given
 		ctx := goajwt.WithJWT(context.Background(), nil)
 		// then
-		assert.False(t, token.IsSpecificServiceAccount(ctx, serviceName))
+		assert.False(s.T(), token.IsSpecificServiceAccount(ctx, serviceName))
 	})
-	t.Run("Wrong data type", func(t *testing.T) {
+	s.T().Run("Wrong data type", func(t *testing.T) {
 		// given
 		claims := jwt.MapClaims{}
 		claims["service_accountname"] = 100
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.False(t, token.IsSpecificServiceAccount(ctx, serviceName))
+		assert.False(s.T(), token.IsSpecificServiceAccount(ctx, serviceName))
 	})
-	t.Run("Missing token", func(t *testing.T) {
+	s.T().Run("Missing token", func(t *testing.T) {
 		// given
 		ctx := context.Background()
 		// then
-		assert.False(t, token.IsSpecificServiceAccount(ctx, serviceName))
+		assert.False(s.T(), token.IsSpecificServiceAccount(ctx, serviceName))
 	})
-	t.Run("Wrong name", func(t *testing.T) {
+	s.T().Run("Wrong name", func(t *testing.T) {
 		// given
 		claims := jwt.MapClaims{}
 		claims["service_accountname"] = serviceName + "_asdsa"
 		ctx := goajwt.WithJWT(context.Background(), jwt.NewWithClaims(jwt.SigningMethodRS512, claims))
 		// then
-		assert.False(t, token.IsSpecificServiceAccount(ctx, serviceName))
+		assert.False(s.T(), token.IsSpecificServiceAccount(ctx, serviceName))
 	})
 }
 
-func createInvalidSAContext() context.Context {
-	claims := jwt.MapClaims{}
-	token := jwt.NewWithClaims(jwt.SigningMethodRS512, claims)
-	return goajwt.WithJWT(context.Background(), token)
-}
-
-func TestAddLoginRequiredHeader(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
-	// given
-	config := testconfiguration.NewDefaultMockTokenManagerConfiguration(t)
-	tm, err := token.NewManager(config)
-	require.NoError(t, err)
-	t.Run("without header set", func(t *testing.T) {
+func (s *TokenManagerTestSuite) TestAddLoginRequiredHeader() {
+	s.T().Run("without header set", func(t *testing.T) {
 		// given
 		rw := httptest.NewRecorder()
 		// when
-		tm.AddLoginRequiredHeader(rw)
+		s.tm.AddLoginRequiredHeader(rw)
 		// then
-		checkLoginRequiredHeader(t, rw)
+		checkLoginRequiredHeader(s.T(), rw)
 	})
-	t.Run("with header set", func(t *testing.T) {
+	s.T().Run("with header set", func(t *testing.T) {
 		// given
 		rw := httptest.NewRecorder()
 		rw.Header().Set("Access-Control-Expose-Headers", "somecustomvalue")
 		// when
-		tm.AddLoginRequiredHeader(rw)
+		s.tm.AddLoginRequiredHeader(rw)
 		// then
-		checkLoginRequiredHeader(t, rw)
+		checkLoginRequiredHeader(s.T(), rw)
 	})
 }
 
@@ -148,40 +154,58 @@ func checkLoginRequiredHeader(t *testing.T, rw http.ResponseWriter) {
 	assert.Contains(t, header["Access-Control-Expose-Headers"], "WWW-Authenticate")
 }
 
-func assertHeaders(t *testing.T, tm token.Manager, tokenString string) {
-	jwtToken, err := tm.Parse(context.Background(), tokenString)
-	assert.NoError(t, err)
-	assert.Equal(t, "aUGv8mQA85jg4V1DU8Uk1W0uKsxn187KQONAGl6AMtc", jwtToken.Header["kid"])
-	assert.Equal(t, "RS256", jwtToken.Header["alg"])
-	assert.Equal(t, "JWT", jwtToken.Header["typ"])
-}
-
-func TestParseValidTokenOK(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
+func (s *TokenManagerTestSuite) TestParseValidTokenOK() {
 	// given
-	config := testconfiguration.NewDefaultMockTokenManagerConfiguration(t)
-	tm, err := token.NewManager(config)
-	require.NoError(t, err)
 	identity := testsupport.NewIdentity()
-	generatedToken, _, err := testsupport.GenerateSignedUserToken(identity, config)
-	require.NoError(t, err)
+	generatedToken, _, err := testsupport.GenerateSignedUserToken(identity, s.config)
+	require.NoError(s.T(), err)
 
-	t.Run("parse token", func(t *testing.T) {
+	s.T().Run("parse token", func(t *testing.T) {
 		// when
-		claims, err := tm.ParseToken(context.Background(), generatedToken)
+		claims, err := s.tm.ParseToken(context.Background(), generatedToken)
 		// then
-		require.Nil(t, err)
-		assert.Equal(t, identity.ID.String(), claims.Subject)
-		assert.Equal(t, identity.Username, claims.Username)
+		require.Nil(s.T(), err)
+		assert.Equal(s.T(), identity.ID.String(), claims.Subject)
+		assert.Equal(s.T(), identity.Username, claims.Username)
 	})
 
-	t.Run("parse", func(t *testing.T) {
+	s.T().Run("parse", func(t *testing.T) {
 		// when
-		jwtToken, err := tm.Parse(context.Background(), generatedToken)
+		jwtToken, err := s.tm.Parse(context.Background(), generatedToken)
 		// then
-		require.Nil(t, err)
-		checkClaim(t, jwtToken, "sub", identity.ID.String())
-		checkClaim(t, jwtToken, "preferred_username", identity.Username)
+		require.Nil(s.T(), err)
+		checkClaim(s.T(), jwtToken, "sub", identity.ID.String())
+		checkClaim(s.T(), jwtToken, "preferred_username", identity.Username)
+	})
+}
+
+func (s *TokenManagerTestSuite) TestAuthServiceURL() {
+	config := testconfiguration.NewDefaultMockTokenManagerConfiguration(s.T())
+
+	s.T().Run("OK if auth URL does not have trailing slash", func(t *testing.T) {
+		config.GetAuthServiceURLFunc = func() string {
+			return "https://auth.prod-preview.openshift.io"
+		}
+		tm, err := token.NewManager(config)
+		require.NoError(s.T(), err)
+		assert.Len(s.T(), tm.PublicKeys(), 3)
+	})
+
+	s.T().Run("OK if auth URL has trailing slash", func(t *testing.T) {
+		config.GetAuthServiceURLFunc = func() string {
+			return "https://auth.prod-preview.openshift.io/"
+		}
+		tm, err := token.NewManager(config)
+		require.NoError(s.T(), err)
+		assert.Len(s.T(), tm.PublicKeys(), 3)
+	})
+
+	s.T().Run("OK if auth URL has trailing slash", func(t *testing.T) {
+		config.GetAuthServiceURLFunc = func() string {
+			return "https://somedomain.com/"
+		}
+		_, err := token.NewManager(config)
+		require.Error(s.T(), err)
 	})
 }
 
@@ -192,35 +216,29 @@ func checkClaim(t *testing.T, token *jwt.Token, claimName string, expectedValue 
 	assert.Equal(t, expectedValue, claim)
 }
 
-func TestParseToken(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
-	// given
-	config := testconfiguration.NewDefaultMockTokenManagerConfiguration(t)
-	tm, err := token.NewManager(config)
-	require.NoError(t, err)
-
-	t.Run("Invalid token format", func(t *testing.T) {
-		checkInvalidToken(t, tm, "7423742yuuiy-INVALID-73842342389h", "token contains an invalid number of segments")
+func (s *TokenManagerTestSuite) TestParseToken() {
+	s.T().Run("Invalid token format", func(t *testing.T) {
+		checkInvalidToken(s.T(), s.tm, "7423742yuuiy-INVALID-73842342389h", "token contains an invalid number of segments")
 	})
 
-	t.Run("Missing kid", func(t *testing.T) {
-		checkInvalidToken(t, tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.mx6DrW3kUQEvsz5Bmaea3nXD9_DB5fBDyNIfanr3u_RFWQyV0romzrAjBP3dKz_dgTS4S5WX2Q1XZiPLjc13PMTCQTNUXp6bFJ5RlDEqX6rJP0Ps9X7bke1pcqS7RhV9cnR1KNH8428bYoKCV57eQnhWtQoCQC1Db6YWJoQNJJLt0IHKCOx7c06r01VF1zcIk1dHnzzz9Qv5aACGXAi8iEJsQ1vURSh7fMETfSJl0UrLJsxGo60fHX9p74cu7bcgD-Zj86axRfgbaHuxn1MMJblltcPsG_TnsMOtmqQr4wlszWTQzwbLnemn8XfwPU8XYc49rVnkiZoB9-BV-oYIxg", "There is no 'kid' header in the token")
+	s.T().Run("Missing kid", func(t *testing.T) {
+		checkInvalidToken(s.T(), s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.mx6DrW3kUQEvsz5Bmaea3nXD9_DB5fBDyNIfanr3u_RFWQyV0romzrAjBP3dKz_dgTS4S5WX2Q1XZiPLjc13PMTCQTNUXp6bFJ5RlDEqX6rJP0Ps9X7bke1pcqS7RhV9cnR1KNH8428bYoKCV57eQnhWtQoCQC1Db6YWJoQNJJLt0IHKCOx7c06r01VF1zcIk1dHnzzz9Qv5aACGXAi8iEJsQ1vURSh7fMETfSJl0UrLJsxGo60fHX9p74cu7bcgD-Zj86axRfgbaHuxn1MMJblltcPsG_TnsMOtmqQr4wlszWTQzwbLnemn8XfwPU8XYc49rVnkiZoB9-BV-oYIxg", "There is no 'kid' header in the token")
 	})
 
-	t.Run("Unknown kid", func(t *testing.T) {
-		checkInvalidToken(t, tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InVua25vd25raWQifQ.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.ewwDOye1c5mA91YjgMQvk0x4RCXeosKVgag-UeG5lHQASWPv3_cpw0BMahG6-eJw1FTvnMFHlcH1Smw-Nfh43qKUpdgWL7QpVbLHiOgvfcsk1g3-G0QFBZ-N-xh35L53Cp5_seXionSAGjsNWLqStQaHPXJ9jLAc_JYLds1VO2CJ0tPSyJ0kiC8fiyRP17pJ19hiHonnGUAZlfZGPJZhrBCfAx3NBbejE0ZAUoeIAw1wPQJDCfp93vO5jvn0kUubpHlnAFz0YtLKqUfaiw6PfZDpu_HTpxAMVvyY_4PxzP56lWdnqQh6JhiMuVNehJfnKcAKPu4WboNCVVIBW3Gppg", "There is no public key with such ID: unknownkid")
+	s.T().Run("Unknown kid", func(t *testing.T) {
+		checkInvalidToken(s.T(), s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InVua25vd25raWQifQ.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.ewwDOye1c5mA91YjgMQvk0x4RCXeosKVgag-UeG5lHQASWPv3_cpw0BMahG6-eJw1FTvnMFHlcH1Smw-Nfh43qKUpdgWL7QpVbLHiOgvfcsk1g3-G0QFBZ-N-xh35L53Cp5_seXionSAGjsNWLqStQaHPXJ9jLAc_JYLds1VO2CJ0tPSyJ0kiC8fiyRP17pJ19hiHonnGUAZlfZGPJZhrBCfAx3NBbejE0ZAUoeIAw1wPQJDCfp93vO5jvn0kUubpHlnAFz0YtLKqUfaiw6PfZDpu_HTpxAMVvyY_4PxzP56lWdnqQh6JhiMuVNehJfnKcAKPu4WboNCVVIBW3Gppg", "There is no public key with such ID: unknownkid")
 	})
 
-	t.Run("Invalid signature", func(t *testing.T) {
-		checkInvalidToken(t, tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC5jb20ifQ.Y66kbPnxdfWyuawsEABDTsPFAylC9UFj934pF7SG-Fwrfqs3iF0gVHAQ56WLwY7E-D4QX_3uUkYuSrjzd4JT1p0bfxt3uu0wzFQlnzB4Uu2ttS287XPkBss4mUlc5uvAj0FRdy1IrQBFnfFpW5s6PWrHqod9PF4R2BTCBO1JqKgRtGzSqFwuWHowW__Sgw3B2NVgplL-6rb762M1OeT0GFWt0QE_uG8k_LPGPTyxDR5AILGfRgz5p-d16SYCAsjbsGSiQh3OGArt3Gzfi3CsKIGsQnhfuVXiorFbUn-nVaDuxRwU7JDzhde5nAj38U7exrkgxhEkybGMe4xZme49vA", "crypto/rsa: verification error")
+	s.T().Run("Invalid signature", func(t *testing.T) {
+		checkInvalidToken(s.T(), s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC5jb20ifQ.Y66kbPnxdfWyuawsEABDTsPFAylC9UFj934pF7SG-Fwrfqs3iF0gVHAQ56WLwY7E-D4QX_3uUkYuSrjzd4JT1p0bfxt3uu0wzFQlnzB4Uu2ttS287XPkBss4mUlc5uvAj0FRdy1IrQBFnfFpW5s6PWrHqod9PF4R2BTCBO1JqKgRtGzSqFwuWHowW__Sgw3B2NVgplL-6rb762M1OeT0GFWt0QE_uG8k_LPGPTyxDR5AILGfRgz5p-d16SYCAsjbsGSiQh3OGArt3Gzfi3CsKIGsQnhfuVXiorFbUn-nVaDuxRwU7JDzhde5nAj38U7exrkgxhEkybGMe4xZme49vA", "crypto/rsa: verification error")
 	})
 
-	t.Run("Expired", func(t *testing.T) {
-		checkInvalidToken(t, tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjExMTk2MDc5NTIsIm5iZiI6MCwiaWF0IjoxMTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.g90TCdckT5YFctQSwQke7jmeGDZQotYiCa8AE_x0o8M8ncgb6m07glGXgcGJXftkzUL-uZn1U9JzixOYaI8B__jtB9BbMqMnrXyz-_gTYHAlj06l-9axVyKV7cpO8IIt_cFVt5lv4pPEcjEMzDLbjxxo6qH9lihry_KL3zESt8hxaosSnY5b8XvN7WCL-5NYTDF_i7QBI5x8XBljQpTJSwLY6-X7TDgAThET8OgWDV3H40UsSSsJUfpdEJZuiDsqoCsEpb0E7AfiYD-y0iZ5ULSxTiNf0EYf26irmy-jyQlWujOSb9kV2utsywZn-zDmHX3W_hS2wRD5eVgePFTBKA", "token is expired")
+	s.T().Run("Expired", func(t *testing.T) {
+		checkInvalidToken(s.T(), s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjExMTk2MDc5NTIsIm5iZiI6MCwiaWF0IjoxMTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.g90TCdckT5YFctQSwQke7jmeGDZQotYiCa8AE_x0o8M8ncgb6m07glGXgcGJXftkzUL-uZn1U9JzixOYaI8B__jtB9BbMqMnrXyz-_gTYHAlj06l-9axVyKV7cpO8IIt_cFVt5lv4pPEcjEMzDLbjxxo6qH9lihry_KL3zESt8hxaosSnY5b8XvN7WCL-5NYTDF_i7QBI5x8XBljQpTJSwLY6-X7TDgAThET8OgWDV3H40UsSSsJUfpdEJZuiDsqoCsEpb0E7AfiYD-y0iZ5ULSxTiNf0EYf26irmy-jyQlWujOSb9kV2utsywZn-zDmHX3W_hS2wRD5eVgePFTBKA", "token is expired")
 	})
 
-	t.Run("OK", func(t *testing.T) {
-		checkValidToken(t, tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.gyoMIWuXnIMMRHewef-__Wkd66qjqSSJxusWcFVtNWaYOXWu7iFV9DhtPVGsbTllXG_lDozPV9BaDmmYRotnn3ZBg7khFDykv9WnoYAjE9vW1d8szNjuoG3tfgQI4Dr9jqopSLndldxq97LGqpxqZFbIDlYd8vN47kv4EePOZDsII6egkTraCMc35eMMilJ4Udd6CMqyV_zaYiGhgAGgeL2ovMFhg_jnc7WhePv7FZkUmtfhCuLUL2TSXS6CyWZYoUDEIcfca6cMzuKOzJoONkDJShNo4u_cQ53duXX_bizdwYNlzBHfIPhSR1LDgV9BXoM6YQnw3It8ReCfF8BEMQ")
+	s.T().Run("OK", func(t *testing.T) {
+		checkValidToken(s.T(), s.tm, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.eyJqdGkiOiIwMjgyYjI5Yy01MTczLTQyZDgtODE0NS1iNDVmYTFlMzUzOGIiLCJleHAiOjAsIm5iZiI6MCwiaWF0IjoxNTE3MDE1OTUyLCJpc3MiOiJ0ZXN0IiwiYXVkIjoiZmFicmljOC1vbmxpbmUtcGxhdGZvcm0iLCJzdWIiOiIyMzk4NDM5OC04NTVhLTQyZDYtYTdmZS05MzZiYjRlOTJhMGMiLCJ0eXAiOiJCZWFyZXIiLCJzZXNzaW9uX3N0YXRlIjoiZWFkYzA2NmMtMTIzNC00YTU2LTlmMzUtY2U3MDdiNTdhNGU5IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sImFwcHJvdmVkIjp0cnVlLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6IlRlc3QiLCJjb21wYW55IjoiIiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdHVzZXIiLCJnaXZlbl9uYW1lIjoiIiwiZmFtaWx5X25hbWUiOiIiLCJlbWFpbCI6InRAdGVzdC50In0.gyoMIWuXnIMMRHewef-__Wkd66qjqSSJxusWcFVtNWaYOXWu7iFV9DhtPVGsbTllXG_lDozPV9BaDmmYRotnn3ZBg7khFDykv9WnoYAjE9vW1d8szNjuoG3tfgQI4Dr9jqopSLndldxq97LGqpxqZFbIDlYd8vN47kv4EePOZDsII6egkTraCMc35eMMilJ4Udd6CMqyV_zaYiGhgAGgeL2ovMFhg_jnc7WhePv7FZkUmtfhCuLUL2TSXS6CyWZYoUDEIcfca6cMzuKOzJoONkDJShNo4u_cQ53duXX_bizdwYNlzBHfIPhSR1LDgV9BXoM6YQnw3It8ReCfF8BEMQ")
 	})
 
 }
@@ -246,8 +264,7 @@ func checkValidToken(t *testing.T, tm token.Manager, token string) {
 	assert.NoError(t, err)
 }
 
-func TestCheckClaimsOK(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
+func (s *TokenManagerTestSuite) TestCheckClaimsOK() {
 	// given
 	claims := &token.TokenClaims{
 		Email:    "somemail@domain.com",
@@ -257,91 +274,83 @@ func TestCheckClaimsOK(t *testing.T) {
 	// when
 	err := token.CheckClaims(claims)
 	// then
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 }
 
-func TestCheckClaimsFails(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
-
-	t.Run("no email", func(t *testing.T) {
+func (s *TokenManagerTestSuite) TestCheckClaimsFails() {
+	s.T().Run("no email", func(t *testing.T) {
 		// given
 		claimsNoEmail := &token.TokenClaims{
 			Username: "testuser",
 		}
 		claimsNoEmail.Subject = uuid.NewV4().String()
 		// then
-		assert.NotNil(t, token.CheckClaims(claimsNoEmail))
+		assert.NotNil(s.T(), token.CheckClaims(claimsNoEmail))
 	})
 
-	t.Run("no username", func(t *testing.T) {
+	s.T().Run("no username", func(t *testing.T) {
 		// given
 		claimsNoUsername := &token.TokenClaims{
 			Email: "somemail@domain.com",
 		}
 		claimsNoUsername.Subject = uuid.NewV4().String()
 		// then
-		assert.NotNil(t, token.CheckClaims(claimsNoUsername))
+		assert.NotNil(s.T(), token.CheckClaims(claimsNoUsername))
 	})
 
-	t.Run("no subject", func(t *testing.T) {
+	s.T().Run("no subject", func(t *testing.T) {
 		// given
 		claimsNoSubject := &token.TokenClaims{
 			Email:    "somemail@domain.com",
 			Username: "testuser",
 		}
 		// then
-		assert.NotNil(t, token.CheckClaims(claimsNoSubject))
+		assert.NotNil(s.T(), token.CheckClaims(claimsNoSubject))
 	})
 }
 
-func TestLocateTokenInContext(t *testing.T) {
-	resource.Require(t, resource.UnitTest)
-	// given
-	config := testconfiguration.NewDefaultMockTokenManagerConfiguration(t)
-	tm, err := token.NewManager(config)
-	require.NoError(t, err)
-
-	t.Run("ok", func(t *testing.T) {
+func (s *TokenManagerTestSuite) TestLocateTokenInContext() {
+	s.T().Run("ok", func(t *testing.T) {
 		// given
 		id := uuid.NewV4()
 		tk := jwt.New(jwt.SigningMethodRS256)
 		tk.Claims.(jwt.MapClaims)["sub"] = id.String()
 		ctx := goajwt.WithJWT(context.Background(), tk)
 		// when
-		foundId, err := tm.Locate(ctx)
+		foundId, err := s.tm.Locate(ctx)
 		// then
-		require.NoError(t, err)
-		assert.Equal(t, id, foundId, "ID in created context not equal")
+		require.NoError(s.T(), err)
+		assert.Equal(s.T(), id, foundId, "ID in created context not equal")
 	})
 
-	t.Run("missing token in context", func(t *testing.T) {
+	s.T().Run("missing token in context", func(t *testing.T) {
 		// given
 		ctx := context.Background()
 		// when
-		_, err = tm.Locate(ctx)
+		_, err := s.tm.Locate(ctx)
 		// then
-		require.Error(t, err)
+		require.Error(s.T(), err)
 	})
 
-	t.Run("missing UUID in token", func(t *testing.T) {
+	s.T().Run("missing UUID in token", func(t *testing.T) {
 		// given
 		tk := jwt.New(jwt.SigningMethodRS256)
 		ctx := goajwt.WithJWT(context.Background(), tk)
 		// when
-		_, err = tm.Locate(ctx)
+		_, err := s.tm.Locate(ctx)
 		// then
-		require.Error(t, err)
+		require.Error(s.T(), err)
 	})
 
-	t.Run("invalid UUID in token", func(t *testing.T) {
+	s.T().Run("invalid UUID in token", func(t *testing.T) {
 		// given
 		tk := jwt.New(jwt.SigningMethodRS256)
 		tk.Claims.(jwt.MapClaims)["sub"] = "131"
 		ctx := goajwt.WithJWT(context.Background(), tk)
 		// when
-		_, err := tm.Locate(ctx)
+		_, err := s.tm.Locate(ctx)
 		// then
-		require.Error(t, err)
+		require.Error(s.T(), err)
 
 	})
 }

--- a/token/token_whitebox_test.go
+++ b/token/token_whitebox_test.go
@@ -19,10 +19,6 @@ func TestKeyLoaded(t *testing.T) {
 		return "https://auth.prod-preview.openshift.io"
 	}
 
-	config.GetAuthKeysPathFunc = func() string {
-		return "/api/token/keys"
-	}
-
 	t.Run("dev mode enabled", func(t *testing.T) {
 		// given
 		config.GetDevModePrivateKeyFunc = func() []byte {


### PR DESCRIPTION
We don't really need to pass `/api/token/keys` as configuration param when loading public keys. It's the same path for all services.

Let's hardcode it in token manager constructor until we extract auth client to a separate repository. Then we could use auth client to get the path.