### PR TITLE
chore: add required files using git add as git commit won't consider untracked files

### DIFF
--- a/.scripts/create_push_client.sh
+++ b/.scripts/create_push_client.sh
@@ -37,7 +37,7 @@ function generate_client_and_create_pr() {
     git rev-parse HEAD > /tmp/${GHREPO}/source_commit.txt
     cd /tmp/${GHREPO}
 
-    git commit ${PKG_NAME} ${TOOL_DIR} source_commit.txt -m "${message}"
+    git add ${PKG_NAME} ${TOOL_DIR} source_commit.txt && git commit -m "${message}"
     git push -q -u origin ${branch}
 
     set +x


### PR DESCRIPTION
`git commit ${PKG_NAME} ${TOOL_DIR} source_commit.txt -m "${message}"` 

Above command won't add untracked files if any(which means files which we are adding first time.) This adds only tracked files due to which client build is failing for https://github.com/fabric8-services/fabric8-cluster-client/pull/26.

Now we are adding all required directories first using `git add ${PKG_NAME} ${TOOL_DIR} source_commit.txt` which will fix the build