### PR TITLE
fix: use epel-testing repository to install golang package

### DIFF
--- a/.make/test.mk
+++ b/.make/test.mk
@@ -139,7 +139,7 @@ test-unit: prebuild-check generate clean-coverage-unit $(COV_PATH_UNIT)
 test-unit-no-coverage: prebuild-check generate $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_UNIT_TEST=1 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
+	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_UNIT_TEST=1 F8_LOG_LEVEL=$(F8_LOG_LEVEL) go test $(GO_TEST_VERBOSITY_FLAG) -vet off $(TEST_PACKAGES)
 
 .PHONY: test-unit-no-coverage-junit
 test-unit-no-coverage-junit: prebuild-check generate ${GO_JUNIT_BIN} ${TMP_PATH}
@@ -312,6 +312,7 @@ $(eval COV_OUT_FILE := $(COV_DIR)/$(PACKAGE_NAME)/coverage.$(TEST_NAME).mode-$(C
 @$(ENV_VAR) F8_DEVELOPER_MODE_ENABLED=1 F8_POSTGRES_HOST=$(F8_POSTGRES_HOST) F8_LOG_LEVEL=$(F8_LOG_LEVEL) \
 	go test  $(PACKAGE_NAME) \
 		$(GO_TEST_VERBOSITY_FLAG) \
+		-vet off \
 		-coverprofile $(COV_OUT_FILE) \
 		-coverpkg $(ALL_PKGS_COMMA_SEPARATED) \
 		-covermode=$(COVERAGE_MODE) \
@@ -464,7 +465,7 @@ endif
 test-integration-no-coverage: prebuild-check generate $(SOURCES)
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_DATABASE=1 F8_RESOURCE_UNIT_TEST=0 go test $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)
+	F8_DEVELOPER_MODE_ENABLED=1 F8_RESOURCE_DATABASE=1 F8_RESOURCE_UNIT_TEST=0 go test $(GO_TEST_VERBOSITY_FLAG) -vet off $(TEST_PACKAGES)
 
 .PHONY: test-integration
 ## Make sure you ran "make integration-test-env-prepare" before you run this target.

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -6,7 +6,7 @@ ARG USE_GO_VERSION_FROM_WEBSITE=0
 
 # Some packages might seem weird but they are required by the RVM installer.
 RUN yum install epel-release --enablerepo=extras -y \
-    && yum --enablerepo=centosplus --enablerepo=epel-testing install -y --quiet \
+    && yum --enablerepo=centosplus --enablerepo=epel-testing install -y \
       findutils \
       git \
       $(test "$USE_GO_VERSION_FROM_WEBSITE" != 1 && echo "golang") \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -5,7 +5,8 @@ ENV LANG=en_US.utf8
 ARG USE_GO_VERSION_FROM_WEBSITE=0
 
 # Some packages might seem weird but they are required by the RVM installer.
-RUN yum --enablerepo=centosplus install -y --quiet \
+RUN yum install epel-release --enablerepo=extras -y \
+    && yum --enablerepo=centosplus --enablerepo=epel-testing install -y --quiet \
       findutils \
       git \
       $(test -z $USE_GO_VERSION_FROM_WEBSITE && echo "golang") \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -9,7 +9,7 @@ RUN yum install epel-release --enablerepo=extras -y \
     && yum --enablerepo=centosplus --enablerepo=epel-testing install -y --quiet \
       findutils \
       git \
-      $(test -z $USE_GO_VERSION_FROM_WEBSITE && echo "golang") \
+      $(test "$USE_GO_VERSION_FROM_WEBSITE" != 1 && echo "golang") \
       make \
       procps-ng \
       tar \
@@ -18,13 +18,13 @@ RUN yum install epel-release --enablerepo=extras -y \
       bc \
     && yum clean all
 
-RUN test -n $USE_GO_VERSION_FROM_WEBSITE \
-    && cd /tmp \
+RUN if [[ "$USE_GO_VERSION_FROM_WEBSITE" = 1 ]]; then cd /tmp \
     && wget --no-verbose https://dl.google.com/go/go1.10.linux-amd64.tar.gz \
     && echo "b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33  go1.10.linux-amd64.tar.gz" > checksum \
     && sha256sum -c checksum \
     && tar -C /usr/local -xzf go1.10.linux-amd64.tar.gz \
-    && rm -f go1.10.linux-amd64.tar.gz
+    && rm -f go1.10.linux-amd64.tar.gz; \
+    fi
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Get dep for Go package management and make sure the directory has full rwz permissions for non-root users

--- a/cico_run_coverage.sh
+++ b/cico_run_coverage.sh
@@ -2,7 +2,7 @@
 
 . cico_setup.sh
 
-export USE_GO_VERSION_FROM_WEBSITE=1
+#export USE_GO_VERSION_FROM_WEBSITE=1
 
 cico_setup;
 

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -33,7 +33,7 @@ function install_deps() {
   /usr/sbin/setenforce 0 || :
 
   # Get all the deps in
-  yum -y install --quiet \
+  yum -y install \
     docker \
     make \
     git \


### PR DESCRIPTION
use `epel-testing` repository to install golang package which was deprecated in CentOS-7
see: https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.1810#head-e467ac744557df926ed56dc0106f43961e5ffc38