### PR TITLE
fix(fabric8-services/fabric8-auth#734): gunzipResponseWriter should return lenght of the original compressed body to avoid panic

### DIFF
--- a/httpsupport/proxy.go
+++ b/httpsupport/proxy.go
@@ -167,7 +167,8 @@ func (w gunzipResponseWriter) Write(b []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return w.ResponseWriter.Write(data)
+	_, err = w.ResponseWriter.Write(data)
+	return len(b), err
 }
 
 func (w gunzipResponseWriter) WriteHeader(code int) {

--- a/httpsupport/proxy_blackbox_test.go
+++ b/httpsupport/proxy_blackbox_test.go
@@ -54,6 +54,8 @@ func TestProxy(t *testing.T) {
 	// POST, gzipped, changed target path
 	rw = httptest.NewRecorder()
 	req, err = http.NewRequest("POST", u.String(), nil)
+	req = req.WithContext(context.WithValue(context.Background(), http.ServerContextKey, "ProxyTest"))
+
 	require.NoError(t, err)
 
 	ctx = context.Background()


### PR DESCRIPTION
The test `TestProxy` is a reproducer of the original issue.
if you change:
```go
_, err = w.ResponseWriter.Write(data)
return len(b), err
```
back to
```go
return w.ResponseWriter.Write(data)
``` 
then running the test you will experience the panic (expecting you are using go 1.11)

fixes: fabric8-services/fabric8-auth#734 (or more likely is a workaround for the issue :-))