### PR TITLE
add support for subtest setup/teardown

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -466,7 +466,7 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:5110e3d4f130772fd39e6ce8208ad1955b242ccfcc8ad9d158857250579c82f4"
+  digest = "1:8ff03ccc603abb0d7cce94d34b613f5f6251a9e1931eba1a3f9888a9029b055c"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -474,8 +474,8 @@
     "suite",
   ]
   pruneopts = "UT"
-  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
-  version = "v1.2.2"
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:7bff42fbbef28d0ef60138c92cb3872cacb035133b3cfa39e3ff2c43f1fc332e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -74,7 +74,7 @@ required = [
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.2.2"
+  version = "v1.3.0"
 
 # [[constraint]]
 #   name = "gopkg.in/asaskevich/govalidator.v4"


### PR DESCRIPTION
use as follow within the `TestXYZ` method:

```
s.SetupSubtest = func() {
	...
}
```
and then simpy run the subtests with:
```
s.Run("name", func() {
 ...
})
```

and use `s.T()` within the subtests.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>